### PR TITLE
Changed rpgdice text/background colour based on roll results

### DIFF
--- a/apps/rpgdice/ChangeLog
+++ b/apps/rpgdice/ChangeLog
@@ -1,1 +1,2 @@
 0.01: First release
+0.02: Colour changes dependent on roll result

--- a/apps/rpgdice/app.js
+++ b/apps/rpgdice/app.js
@@ -14,12 +14,18 @@ function getDie() {
 }
 
 function setColors(lastBounce) {
-  if (lastBounce) {
-    bgColor = 0xFFFF;
+  if (lastBounce && face == getDie()) {
+    bgColor = 0x0000; // Critical Hit
+    fgColor = 0xF800;
+  } else if (lastBounce && face == 1){
+    bgColor = 0xF800; // Critical Miss
     fgColor = 0x0000;
-  } else {
-    bgColor = 0x0000
+  } else if (lastBounce){
+    bgColor = 0x0000; // Other Result
     fgColor = 0xFFFF;
+  } else {
+    bgColor = 0x0000; // Still Rolling
+    fgColor = 0x7BEF;
   }
 }
 


### PR DESCRIPTION
Purely cosmetic. Changed text colour to grey while bouncing, changing to white on final bounce except for critical rolls. Critical hit is red text on black, critical miss is black text on red.